### PR TITLE
Add Borer& weePickle benchmarks and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Compares performance of several JSON parsers used in Scala:
 - [sphere-json](https://github.com/sphereio/sphere-scala-libs/tree/master/json)
 - [spray-json](https://github.com/spray/spray-json)
 - [jsoniter-scala](https://github.com/plokhotnyuk/jsoniter-scala)
-- [uJson](http://www.lihaoyi.com/upickle/#uJson)
+- [uPickle](http://www.lihaoyi.com/upickle)
 - [refuel-json](https://github.com/giiita/refuel)
 
 The test case is to deserialize a json into a case class and to serialize back to json.

--- a/build.sbt
+++ b/build.sbt
@@ -2,32 +2,35 @@ name := """json-perf"""
 
 version := "1.0"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.11"
 
-val json4sVersion = "3.5.4"
-val playVersion = "2.6.9"
-val circeVersion = "0.9.3"
+val json4sVersion = "3.7.0-M2"
+val circeVersion = "0.13.0"
 
-resolvers += Resolver.bintrayRepo("commercetools", "maven")
-
-libraryDependencies ++=
-  "io.circe"                              %% "circe-core"           % circeVersion  ::
-  "io.circe"                              %% "circe-generic"        % circeVersion  ::
-  "io.circe"                              %% "circe-parser"         % circeVersion  ::
-  "com.fasterxml.jackson.module"          %% "jackson-module-scala" % "2.9.5"       ::
-  "org.json4s"                            %% "json4s-native"        % json4sVersion ::
-  "org.json4s"                            %% "json4s-jackson"       % json4sVersion ::
-  "io.sphere"                             %% "sphere-json"          % "0.9.13"      ::
-  "com.typesafe.play"                     %% "play-json"            % playVersion   ::
-  "io.spray"                              %% "spray-json"           % "1.3.4"       ::
-  "io.argonaut"                           %% "argonaut"             % "6.2.2"       ::
-  "com.github.plokhotnyuk.jsoniter-scala" %% "macros"               % "0.28.0"      ::
-  "com.lihaoyi"                           %% "upickle"              % "0.6.6"       ::
-  "com.phylage"                           %% "refuel-json"          % "1.0.1"       ::
+resolvers ++=
+  Resolver.bintrayRepo("commercetools", "maven") ::
+  Resolver.bintrayRepo("rallyhealth", "maven")   ::
   Nil
 
 libraryDependencies ++=
-  "org.scalatest"                         %% "scalatest"            % "3.0.5"       ::
+  "io.circe"                              %% "circe-generic"         % circeVersion  ::
+  "io.circe"                              %% "circe-parser"          % circeVersion  ::
+  "com.fasterxml.jackson.module"          %% "jackson-module-scala"  % "2.10.3"      ::
+  "org.json4s"                            %% "json4s-native"         % json4sVersion ::
+  "org.json4s"                            %% "json4s-jackson"        % json4sVersion ::
+  "io.sphere"                             %% "sphere-json"           % "0.11.2"      ::
+  "com.typesafe.play"                     %% "play-json"             % "2.8.1"       ::
+  "io.spray"                              %% "spray-json"            % "1.3.5"       ::
+  "io.argonaut"                           %% "argonaut"              % "6.2.5"       ::
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.1.7"       ::
+  "com.lihaoyi"                           %% "upickle"               % "1.0.0"       ::
+  "com.phylage"                           %% "refuel-json"           % "1.0.1"       ::
+  "io.bullet"                             %% "borer-derivation"      % "1.5.0"       ::
+  "com.rallyhealth"                       %% "weepickle-v1"          % "1.0.1"       ::
+  Nil
+
+libraryDependencies ++=
+  "org.scalatest"                         %% "scalatest"             % "3.1.1"       ::
   Nil map (_ % Test)
 
 parallelExecution in Test := false

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")

--- a/src/main/scala/jsonperf/JmhBenchmarks.scala
+++ b/src/main/scala/jsonperf/JmhBenchmarks.scala
@@ -8,56 +8,80 @@ import org.openjdk.jmh.annotations._
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-abstract class JmhBenchmarks[A <: AnyRef](val test: JsonTest[A]) {
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgs = Array(
+  "-server",
+  "-Xms1g",
+  "-Xmx1g",
+  "-XX:NewSize=512m",
+  "-XX:MaxNewSize=512m",
+  "-XX:InitialCodeCacheSize=256m",
+  "-XX:ReservedCodeCacheSize=256m",
+  "-XX:+UseParallelGC",
+  "-XX:-UseAdaptiveSizePolicy",
+  "-XX:MaxInlineLevel=18",
+  "-XX:-UseBiasedLocking",
+  "-XX:+AlwaysPreTouch",
+  "-XX:+UseNUMA",
+  "-XX:-UseAdaptiveNUMAChunkSizing"
+))
+abstract class JmhBenchmarks[A <: AnyRef, B](val test: JsonTest[A]) {
   import test._
 
-  def runTest(implementation: JsonParsing[A]): Unit
+  def runTest(implementation: JsonParsing[A]): B
 
   @Benchmark
-  def runRefuelParsing() = runTest(refuelParsing)
+  def runRefuelParsing: B = runTest(refuelParsing)
 
   @Benchmark
-  def runNoParsing() = runTest(noParsing)
+  def runNoParsing: B = runTest(noParsing)
 
   @Benchmark
-  def runJacksonParsing() = runTest(jacksonParsing)
+  def runJacksonParsing: B = runTest(jacksonParsing)
 
   @Benchmark
-  def runJson4sNative() = runTest(json4sNative)
+  def runJson4sNative: B = runTest(json4sNative)
 
   @Benchmark
-  def runJson4sJackson() = runTest(json4sJackson)
+  def runJson4sJackson: B = runTest(json4sJackson)
 
   @Benchmark
-  def runSphereJson() = runTest(sphereJson)
+  def runSphereJson: B = runTest(sphereJson)
 
   @Benchmark
-  def runPlayJson() = runTest(playJson)
+  def runPlayJson: B = runTest(playJson)
 
   @Benchmark
-  def runSprayJson() = runTest(sprayJson)
+  def runSprayJson: B = runTest(sprayJson)
 
   @Benchmark
-  def runArgonautJson() = runTest(argonautJson)
+  def runArgonautJson: B = runTest(argonautJson)
 
   @Benchmark
-  def runCirce() = runTest(circeJson)
+  def runCirce: B = runTest(circeJson)
 
   @Benchmark
-  def runJsoniter() = runTest(jsoniter)
+  def runJsoniter: B = runTest(jsoniter)
 
   @Benchmark
-  def runUJson() = runTest(uJson)
+  def runUPickle: B = runTest(uPickle)
+
+  @Benchmark
+  def runWeePickle: B = runTest(weePickle)
+
+  @Benchmark
+  def runBorer: B = runTest(borer)
 }
 
-class BigJsonBenchmarkDeserialize extends JmhBenchmarks(new BigJsonTest) {
-  def runTest(implementation: JsonParsing[BigJson]): Unit = {
+class BigJsonBenchmarkDeserialize extends JmhBenchmarks[BigJson, BigJson](new BigJsonTest) {
+  def runTest(implementation: JsonParsing[BigJson]): BigJson = {
     implementation.deserialize(test.json)
   }
 }
 
-class BigJsonBenchmarkSerialize extends JmhBenchmarks(new BigJsonTest) {
-  def runTest(implementation: JsonParsing[BigJson]): Unit = {
+class BigJsonBenchmarkSerialize extends JmhBenchmarks[BigJson, String](new BigJsonTest) {
+  def runTest(implementation: JsonParsing[BigJson]): String = {
     implementation.serialize(test.newA)
   }
 }

--- a/src/main/scala/jsonperf/JsonTest.scala
+++ b/src/main/scala/jsonperf/JsonTest.scala
@@ -2,46 +2,45 @@ package jsonperf
 
 import java.nio.charset.StandardCharsets
 
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
-import refuel.json.{Codec, JsonTransform}
-
 abstract class JsonTest[A <: AnyRef](implicit ev: scala.reflect.Manifest[A]) extends Serializable {
 
   def json: String
   def newA: A
   def clazz: Class[A]
-  def refuelCodec: Codec[A]
+  def refuelCodec: refuel.json.Codec[A]
   def sphereJSON: io.sphere.json.JSON[A]
   def playFormat: play.api.libs.json.Format[A]
   def sprayJsonFormat: spray.json.JsonFormat[A]
   def argonautCodec: argonaut.CodecJson[A]
   def circeEncoder: io.circe.Encoder[A]
   def circeDecoder: io.circe.Decoder[A]
-  def jsoniterCodec: JsonValueCodec[A]
-  def uJsonRW: upickle.default.ReadWriter[A]
+  def jsoniterCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[A]
+  def uPickleRW: upickle.default.ReadWriter[A]
+  def weePickleFromTo: com.rallyhealth.weepickle.v1.WeePickle.FromTo[A]
+  def borerCodec: io.bullet.borer.Codec[A]
 
   def checkResult(result: A): Unit
 
 
   type Parsing = JsonParsing[A]
 
-  val refuelParsing = new Parsing with JsonTransform {
-    val codec: Codec[A] = refuelCodec
+  val refuelParsing = new Parsing with refuel.json.JsonTransform {
+    val codec: refuel.json.Codec[A] = refuelCodec
     override def deserialize(json: String): A = json.as[A](codec).right.get
     override def serialize(a: A): String = a.toJString(codec)
-    override def toString(): String = "refuelParsing"
+    override def toString: String = "refuelParsing"
   }
 
   val noParsing: Parsing = new Parsing {
     override def deserialize(json: String): A = newA
     override def serialize(a: A): String = ""
-    override def toString(): String = "noParsing"
+    override def toString: String = "noParsing"
   }
 
   val jacksonParsing: Parsing = new Parsing {
     override def deserialize(json: String): A = Jackson.mapper.readValue(json, clazz)
     override def serialize(a: A): String = Jackson.mapper.writeValueAsString(a)
-    override def toString(): String = "jackson"
+    override def toString: String = "jackson"
   }
 
   val json4sNative: Parsing = new Parsing {
@@ -55,7 +54,7 @@ abstract class JsonTest[A <: AnyRef](implicit ev: scala.reflect.Manifest[A]) ext
     override def serialize(a: A): String = {
       Serialization.write(a)
     }
-    override def toString(): String = "json4sNative"
+    override def toString: String = "json4sNative"
   }
 
   val json4sJackson: Parsing = new Parsing {
@@ -69,7 +68,7 @@ abstract class JsonTest[A <: AnyRef](implicit ev: scala.reflect.Manifest[A]) ext
     override def serialize(a: A): String = {
       Serialization.write(a)
     }
-    override def toString(): String = "json4sJackson"
+    override def toString: String = "json4sJackson"
   }
 
   val sphereJson: Parsing = new Parsing {
@@ -80,7 +79,7 @@ abstract class JsonTest[A <: AnyRef](implicit ev: scala.reflect.Manifest[A]) ext
     override def serialize(a: A): String = {
       io.sphere.json.toJSON(a)(fromToJson)
     }
-    override def toString(): String = "sphereJson"
+    override def toString: String = "sphereJson"
   }
 
   val playJson: Parsing = new Parsing {
@@ -93,7 +92,7 @@ abstract class JsonTest[A <: AnyRef](implicit ev: scala.reflect.Manifest[A]) ext
       import play.api.libs.json.Json
       Json.stringify(Json.toJson(a)(format))
     }
-    override def toString(): String = "playJson"
+    override def toString: String = "playJson"
   }
 
   val sprayJson: Parsing = new Parsing {
@@ -105,7 +104,7 @@ abstract class JsonTest[A <: AnyRef](implicit ev: scala.reflect.Manifest[A]) ext
       import spray.json._
       a.toJson(format).compactPrint
     }
-    override def toString(): String = "sprayJson"
+    override def toString: String = "sprayJson"
   }
 
   val argonautJson: Parsing = new Parsing {
@@ -118,45 +117,66 @@ abstract class JsonTest[A <: AnyRef](implicit ev: scala.reflect.Manifest[A]) ext
       import argonaut.Argonaut._
       a.asJson(codec).toString()
     }
-
-    override def toString(): String = "argonaut"
+    override def toString: String = "argonaut"
   }
 
   val circeJson: Parsing = new Parsing {
     val encoder = circeEncoder
     val decoder = circeDecoder
     override def deserialize(json: String): A = {
-      import io.circe.parser.decode
-      decode[A](json)(decoder).getOrElse(throw new Exception)
+      io.circe.parser.decode[A](json)(decoder).getOrElse(throw new Exception)
     }
     override def serialize(a: A): String = {
       import io.circe.syntax._
       a.asJson(encoder).noSpaces
     }
-
-    override def toString(): String = "circe"
+    override def toString: String = "circe"
   }
 
   val jsoniter: Parsing = new Parsing {
     import com.github.plokhotnyuk.jsoniter_scala.core._
     val codec = jsoniterCodec
     override def deserialize(s: String): A = {
-      readFromArray(s.getBytes(StandardCharsets.UTF_8))(codec)
+      readFromString(s)(codec)
     }
     override def serialize(a: A): String = {
-      new String(writeToArray(a)(codec), StandardCharsets.UTF_8)
+      writeToString(a)(codec)
     }
-    override def toString(): String = "jsoniter"
+    override def toString: String = "jsoniter"
   }
 
-  val uJson: Parsing = new Parsing {
+  val uPickle: Parsing = new Parsing {
     override def deserialize(s: String): A = {
-      upickle.default.read[A](s)(uJsonRW)
+      upickle.default.read[A](s)(uPickleRW)
     }
-
     override def serialize(a: A): String = {
-      upickle.default.write[A](a)(uJsonRW)
+      upickle.default.write[A](a)(uPickleRW)
     }
-    override def toString(): String = "uJson"
+    override def toString: String = "uPickle"
+  }
+
+  val weePickle: Parsing = new Parsing {
+    import com.rallyhealth.weejson.v1.jackson._
+    import com.rallyhealth.weepickle.v1.WeePickle._
+    val fromTo = weePickleFromTo
+    override def deserialize(s: String): A = {
+      FromJson(s).transform(ToScala[A](fromTo))
+    }
+    override def serialize(a: A): String = {
+      FromScala(a)(fromTo).transform(ToJson.string)
+    }
+    override def toString: String = "weePickle"
+  }
+
+  val borer: Parsing = new Parsing {
+    import io.bullet.borer.{Codec, Decoder, Encoder, Json}
+    implicit val Codec(encoder: Encoder[A], decoder: Decoder[A]) = borerCodec
+    override def deserialize(s: String): A = {
+      Json.decode(s.getBytes(StandardCharsets.UTF_8)).to[A].value
+    }
+    override def serialize(a: A): String = {
+      Json.encode(a).toUtf8String
+    }
+    override def toString: String = "borer"
   }
 }

--- a/src/test/scala/jsonperf/UnitTest.scala
+++ b/src/test/scala/jsonperf/UnitTest.scala
@@ -15,7 +15,7 @@ class UnitTest extends FreeSpec with Matchers with TableDrivenPropertyChecks {
       import test._
       val jsonParsings = Table(
         "parser",
-        argonautJson, jacksonParsing, json4sJackson, json4sNative, playJson, sphereJson, sprayJson, circeJson, jsoniter, uJson)
+        argonautJson, jacksonParsing, json4sJackson, json4sNative, playJson, sphereJson, sprayJson, circeJson, jsoniter, uPickle, weePickle, borer)
 
       forAll(jsonParsings) { jsonParsing ⇒
         s"using parser '$jsonParsing'" - {


### PR DESCRIPTION
/cc @sirthias and @htmldoug

Results using the latest build of OpenJDK 15:
```
[info] Benchmark                                      Mode  Cnt   Score    Error  Units
[info] BigJsonBenchmarkDeserialize.runArgonautJson    avgt   10   0.714 ±  0.002  ms/op
[info] BigJsonBenchmarkDeserialize.runBorer           avgt   10   0.155 ±  0.001  ms/op
[info] BigJsonBenchmarkDeserialize.runCirce           avgt   10   0.331 ±  0.001  ms/op
[info] BigJsonBenchmarkDeserialize.runJacksonParsing  avgt   10   0.177 ±  0.001  ms/op
[info] BigJsonBenchmarkDeserialize.runJson4sJackson   avgt   10   1.425 ±  0.002  ms/op
[info] BigJsonBenchmarkDeserialize.runJson4sNative    avgt   10   1.610 ±  0.005  ms/op
[info] BigJsonBenchmarkDeserialize.runJsoniter        avgt   10   0.076 ±  0.001  ms/op
[info] BigJsonBenchmarkDeserialize.runNoParsing       avgt   10  ≈ 10⁻⁵           ms/op
[info] BigJsonBenchmarkDeserialize.runPlayJson        avgt   10   0.663 ±  0.004  ms/op
[info] BigJsonBenchmarkDeserialize.runRefuelParsing   avgt   10   0.415 ±  0.001  ms/op
[info] BigJsonBenchmarkDeserialize.runSphereJson      avgt   10   0.306 ±  0.001  ms/op
[info] BigJsonBenchmarkDeserialize.runSprayJson       avgt   10   0.335 ±  0.001  ms/op
[info] BigJsonBenchmarkDeserialize.runUPickle         avgt   10   0.283 ±  0.001  ms/op
[info] BigJsonBenchmarkDeserialize.runWeePickle       avgt   10   0.203 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runArgonautJson      avgt   10   0.605 ±  0.002  ms/op
[info] BigJsonBenchmarkSerialize.runBorer             avgt   10   0.132 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runCirce             avgt   10   0.362 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runJacksonParsing    avgt   10   0.091 ±  0.002  ms/op
[info] BigJsonBenchmarkSerialize.runJson4sJackson     avgt   10   1.551 ±  0.003  ms/op
[info] BigJsonBenchmarkSerialize.runJson4sNative      avgt   10   2.132 ±  0.004  ms/op
[info] BigJsonBenchmarkSerialize.runJsoniter          avgt   10   0.054 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runNoParsing         avgt   10  ≈ 10⁻⁵           ms/op
[info] BigJsonBenchmarkSerialize.runPlayJson          avgt   10   0.767 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runRefuelParsing     avgt   10   0.676 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runSphereJson        avgt   10   0.214 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runSprayJson         avgt   10   0.300 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runUPickle           avgt   10   0.653 ±  0.001  ms/op
[info] BigJsonBenchmarkSerialize.runWeePickle         avgt   10   0.129 ±  0.001  ms/op
```